### PR TITLE
Fix typo

### DIFF
--- a/2-parser.md
+++ b/2-parser.md
@@ -103,7 +103,7 @@ From your top-level directory, doing:
 
     make bin/c_parser
 
-should create a programe called... `bin/c_parser`.
+should create a programme called... `bin/c_parser`.
 
 
 


### PR DESCRIPTION
In the spirit of British English, `programme` over `program`
